### PR TITLE
Correct NixOS install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently available for `ghc865`, `ghc864` and `ghc844`:
 
 ```nix
 environment.systemPackages = [
-  (import (builtins.fetchTarball "https://github.com/hercules-ci/ghcide-nix/tarball/master")).ghcide-ghc865
+  (import (builtins.fetchTarball "https://github.com/hercules-ci/ghcide-nix/tarball/master") {}).ghcide-ghc865
 ];
 ```
 


### PR DESCRIPTION
The instructions as they were resulted in an error:
```
error: value is a function while a set was expected, at /etc/nixos/configuration.nix:210:5
```