### PR TITLE
Fix mkGhcide defaults

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,8 +19,8 @@ let
               packages.ghcide.configureFlags = [ "--enable-executable-dynamic" ];
             })];
           };
-      mkGhcide = args@{ghc ? pkgs.haskell-nix.compiler.ghc865, stackYaml ? "stack.yaml"}:
-        let packages = mkPackages args;
+      mkGhcide = args@{...}:
+        let packages = mkPackages ({ghc = pkgs.haskell-nix.compiler.ghc865; stackYaml = "stack.yaml"; } // args);
         in packages.ghcide.components.exes.ghcide // { inherit packages; };
     in { export = {
           # ghcide-ghc881 = mkHieCore { ghc = pkgs.haskell-nix.compiler.ghc881; stackYaml = "stack88.yaml"; };


### PR DESCRIPTION
As it turns out in nix it holds:

((args@{a ? "a"}: args) {}) == {}

so the code I provided for the defaults didn‘t work. (Also it didn‘t contain an ellipsis, so I didn‘t allow any other arguments.) Now I have tested this. The new version should work. Sorry for the noise.