### PR TITLE
Adds IOHK cachix dependency info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## 1. Use Cachix to avoid compilation (optional if you like compiling for 2h)
 
     $ nix-env -iA cachix -f https://cachix.org/api/v1/install
+    $ cachix use iohk
     $ cachix use ghcide-nix
 
 ## 2. Install ghcide


### PR DESCRIPTION
As far as I'm aware, if you don't have IOHK added to your set of trusted substituters/public keys then `ghcide-nix` won't pull from the binary cache and it'll force a rebuild of several GHC versions on the user's machine.

It might be useful to elucidate a bit as to why this is the case, but for now I think just having the extra line of instruction should help avoid situations where people are hitting multi-hour GHC compilations even after they believe their caches should have all been in-order.

If this _isn't_ the case then I'd love to hear what I've been doing wrong about with my local setup, since I've had to perform this myself (and I've advised others to do so on their machines).